### PR TITLE
Downgrade to .NET Standard 2.0

### DIFF
--- a/Oz.RateLimitedHttpClient.csproj
+++ b/Oz.RateLimitedHttpClient.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>Oz.RateLimiting</RootNamespace>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Joshua Ozeri</Authors>
         <Description>An HttpClient wrapper implementing SimpleRateLimiter.</Description>
         <RepositoryUrl>https://github.com/XeClutch/Oz.RateLimitedHttpClient</RepositoryUrl>
+        <LangVersion>7.3</LangVersion>
+        <Version>1.0.1</Version>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Oz.SimpleRateLimiter" Version="1.0.0" />
+      <PackageReference Include="Oz.SimpleRateLimiter" Version="1.0.1" />
     </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Oz.RateLimitedHttpClient <a href="https://www.nuget.org/packages/Oz.RateLimitedHttpClient"><img alt="NuGet" src="https://badgen.net/badge/Oz.RateLimitedHttpClient/v1.0.0/blue?icon=nuget"/></a>
+﻿# Oz.RateLimitedHttpClient <a href="https://www.nuget.org/packages/Oz.RateLimitedHttpClient"><img alt="NuGet" src="https://badgen.net/badge/Oz.RateLimitedHttpClient/v1.0.1/blue?icon=nuget"/></a>
 RateLimitHttpClient is a HttpClient wrapper implementing [SimpleRateLimiter](https://www.github.com/XeClutch/Oz.SimpleRateLimiter).
 
 ## Usage

--- a/RateLimitedHttpClient.cs
+++ b/RateLimitedHttpClient.cs
@@ -1,4 +1,12 @@
-﻿namespace Oz.RateLimiting;
+﻿using System.Net.Http;
 
-public class RateLimitedHttpClient(SimpleRateLimiter rateLimiter)
-    : HttpClient(new RateLimitedDelegatingHandler(rateLimiter, new HttpClientHandler())) { }
+namespace Oz.RateLimiting {
+    public class RateLimitedHttpClient : HttpClient {
+        private SimpleRateLimiter _rateLimiter;
+
+        public RateLimitedHttpClient(SimpleRateLimiter rateLimiter) : base(
+            new RateLimitedDelegatingHandler(rateLimiter, new HttpClientHandler())) {
+            _rateLimiter = rateLimiter;
+        }
+    }
+}


### PR DESCRIPTION
Downgrade the project from .NET 8 to .NET Standard 2.0.

This will significantly increase compatibility with this project, allowing much older code bases to adopt RateLimitedHttpClient.